### PR TITLE
Add message when a user joins an event and is waitlisted

### DIFF
--- a/commands/join.js
+++ b/commands/join.js
@@ -27,6 +27,9 @@ module.exports = {
       }
 
       await db.fireteams.put(message.author.id, event.id, reserve);
+      if (reserve) { 
+        message.author.send('You have been added to the waitlist for this raid as it is currently full.');
+      }
       message.react('✅');
     } catch (err) {
       throw new Error(err);


### PR DESCRIPTION
Previously a user could join an event, be waitlisted instead of normally joined, and not know.  Now the user will receive a DM from the bot.