### PR TITLE
Add optional filter (username) to next command

### DIFF
--- a/commands/next.js
+++ b/commands/next.js
@@ -5,8 +5,14 @@ module.exports = {
   run: async (client, message, args) => {
     try {
       let user = await db.users.getByDiscordId(message.author.id);
-      let events = await db.events.getNext();
       let messageString = '';
+      let filter;
+
+      if (args[0]) {
+        filter = `%${client.users.find(user => user.username.toLowerCase() === args[0].toLowerCase()).id}%`;
+      }
+
+      let events = await db.events.getNext(filter);
 
       for (let i = 0; i < events.length; i++) {
         let event = events[i];
@@ -19,5 +25,5 @@ module.exports = {
     }
   },
 
-  help: 'Show the next 3 events.'
+  help: 'Show the next 3 events.  You can include a Discord username as an argument to view events that user has joined.'
 };

--- a/utils/database/events.js
+++ b/utils/database/events.js
@@ -34,9 +34,13 @@ module.exports = pool => ({
     }
   },
 
-  getNext: async () => {
+  getNext: async (filter='%') => {
     try {
-      let [rows, fields] = await pool.query('SELECT * FROM vw_next_3_events;');
+      let [rows, fields] = await pool.query('SELECT * FROM vw_next_3_events WHERE fireteam LIKE :filter;',
+        {
+          filter
+        }
+      );
       return rows;
     } catch (err) {
       throw new Error(err);


### PR DESCRIPTION
## Description
<!-- Outline what feature this PR adds and why this is necessary -->
Adding optional Discord username filter to !next command to allow users to see events they or other people are members of.

## Risks
<!-- Please outline any risks that this PR introduces or eliminates -->
There are no risks associated with this PR.

## Fixes
<!-- Which feature reqeusts does this PR resolve? 
- MacND/voluspa/issues/1
- MacND/voluspa/issues/2
- MacND/voluspa/issues/3
-->
Fixes https://github.com/MacND/voluspa/issues/13
