### PR TITLE
Fix raidreport command not adding reports

### DIFF
--- a/utils/database/events.js
+++ b/utils/database/events.js
@@ -98,7 +98,7 @@ module.exports = pool => ({
         rows,
         fields
       ] = await pool.query(
-        'UPDATE events SET raidReportUrl = :rrLink WHERE id = :eventId',
+        'UPDATE events SET raid_report_url = :rrLink WHERE id = :eventId',
         {
           rrLink,
           eventId


### PR DESCRIPTION
## What
<!-- Please outline what you are doing. -->
Changing the target field for the raidreport command

## Why
<!-- Please outline why you are doing it. -->
It was referencing a camelCase field instead of snake_case and therefor not filling in reports

## Risks
<!-- 
Please replace this text with any risks associated with the PR and what you have done to mitigate them.
If not applicable please indicate with N/A
-->
N/A

## Testing
<!-- Please tick the action you have taken. -->
- [ ] I have tested this change
- [x] I have not tested this change
- [ ] Testing is not applicable to this change